### PR TITLE
Add a LICENSE.md file.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2019 Samy Pesse 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
I realize it's already marked in the package.json, but GitHub can't find that and neither can a lot of other automated tools.  This just adds a LICENSE.md file of the same license (Apache 2) for easier license automation.  (And to make it clear to users who aren't used to digging into the package.json file.)