### PR TITLE
Add suport for remote data sources for code fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,8 @@ var React = require('react')
 {%- endcodetabs %}
 ```
 
+### Remote code sources
 
-
+Alternatively, you may provide a `url` attribute for a given language.  In that case,
+the body of the block is ignored and the content of the remote URL is used instead. The
+syntax highlighting is still controlled by the `type` attribute.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var escape = require('escape-html');
-const fetch = require("node-fetch");
+var fetch = require('node-fetch');
 
 /*
     Generate HTML for the tab in the header


### PR DESCRIPTION
We needed to make this addition for our own use, so I figure it's worth offering back.

Basically, this integrates the functionality of the codesnippet plugin into this plugin.  If you add a url attribute to a tag, then the body gets replaced with the result of that URL.  The intent is to have "live code" that we can run and make sure it always works, and them embed that into documentation knowing that it works.